### PR TITLE
Removing codepen social link

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,11 +181,6 @@
                     </a>
                 </li>
                 <li class="social-list__item">
-                    <a href="https://codepen.io/TomerBenRachel" class="social-list__link" target="_blank" title="CodePen Profile">
-                        <i class="fab fa-codepen"></i>
-                    </a>
-                </li>
-                <li class="social-list__item">
                     <a href="https://play.google.com/store/apps/developer?id=tomerpacific" class="social-list__link" target="_blank" title="Google Play Store Profile">
                         <i class="fab fa-google-play"></i>
                     </a>


### PR DESCRIPTION
Resolves #6 
This pull request removes the link to the CodePen profile from the social links section in the `index.html` file.

Key change:

* Removed the `<li>` element containing the CodePen profile link from the social links section to streamline the list of social profiles.